### PR TITLE
chore: linearB endpoint deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the following to your `pipeline.yaml`:
   - label: "linearB: record the time of deployment"
     command: bin/ci_noop
     plugins:
-      - cultureamp/linearb-cycle-time#v1.1.1: ~
+      - cultureamp/linearb-cycle-time#v1.1.2: ~
 ```
 
 Keep in mind that you only want to call the linearB API once and your pipeline may include multiple production deploys (US, EU). You will likely need to restrict when this plugin executes. This will depend on how the pipeline has been structured but may include branch and/or step dependencies as illustrated below:
@@ -26,7 +26,7 @@ Keep in mind that you only want to call the linearB API once and your pipeline m
     command: bin/ci_noop
     branch: main
     plugins:
-      - cultureamp/linearb-cycle-time#v1.1.1: ~
+      - cultureamp/linearb-cycle-time#v1.1.2: ~
 ```
 
 ### Modifying the default values (likely not required for most users)
@@ -43,7 +43,7 @@ Whilst the plugin is able to pull these values from Buildkite environment variab
   - label: "linearB: record the time of deployment"
     command: bin/ci_noop
     plugins:
-      - cultureamp/linearb-cycle-time#v1.1.1:
+      - cultureamp/linearb-cycle-time#v1.1.2:
           api_key_ssm_param_name: "foo/bar/key"
           repo: "https://github.com/org/repo.git"
           sha: "abcdef..."

--- a/hooks/command
+++ b/hooks/command
@@ -27,19 +27,15 @@ record_deploy_time() {
     api_key=$BUILDKITE_PLUGIN_LINEARB_CYCLE_TIME_API_KEY
   fi
 
-  event_time=$(date +%s)
-
   json=$(jq -n \
-    --argjson event_time "$event_time" \
-    --arg stage_id "release" \
     --arg repo_url "$repo" \
     --arg sha "$sha" \
-    '{event_time: $event_time, repo_url: $repo_url, stage_id: $stage_id, head_sha: $sha}')  
+    '{repo_url: $repo_url, ref_name: $sha}')  
 
   echo "--- :linearb: request payload: ${json}"
 
   status_code=$(curl --write-out "%{http_code}" --silent --output /dev/null \
-    -X POST "https://public-api.linearb.io/api/v1/cycle-time-stages" \
+    -X POST "https://public-api.linearb.io/api/v1/deployments" \
     -H "X-Api-Key:${api_key}" -i \
     -H "Content-Type: application/json" \
     -d "$json" \


### PR DESCRIPTION
- The linearB `cycle-time-stages` endpoint has been deprecated in favour of their new `deployments` endpoint.
- This plugin has been updated to use the new endpoints
- API spec: https://public-api.linearb.io/redoc#tag/deployments